### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL scheme check

### DIFF
--- a/test/fuzz.test.js
+++ b/test/fuzz.test.js
@@ -753,7 +753,8 @@ describe('Fuzz Testing (Property-based Testing)', () => {
               if (res) {
                 const decoded = fullyDecodeAndStrip(res);
                 if (decoded.startsWith('javascript:') ||
-                    decoded.startsWith('vbscript:')) {
+                    decoded.startsWith('vbscript:') ||
+                    decoded.startsWith('data:')) {
                   console.error(
                     'Bypass detected via Scheme Splitting URL:',
                     directUrl, '\nResult:', res
@@ -774,7 +775,8 @@ describe('Fuzz Testing (Property-based Testing)', () => {
               if (res && typeof res === 'string') {
                 const decoded = fullyDecodeAndStrip(res);
                 if (decoded.includes('javascript:') ||
-                    decoded.includes('vbscript:')) {
+                    decoded.includes('vbscript:') ||
+                    decoded.includes('data:')) {
                   console.error(
                     'Bypass detected via Scheme Splitting Data URL:',
                     dataUrl, '\nResult:', res


### PR DESCRIPTION
Potential fix for [https://github.com/asamuzaK/urlSanitizer/security/code-scanning/12](https://github.com/asamuzaK/urlSanitizer/security/code-scanning/12)

To fix this, extend the scheme checks in `test/fuzz.test.js` so they also reject `data:` anywhere the test currently rejects `javascript:`/`vbscript:` as dangerous output.

Best single fix without changing intended functionality:
- In the direct URL result check (around lines 755–756), add `decoded.startsWith('data:')`.
- In the data URL result check (around lines 776–777), add `decoded.includes('data:')` alongside existing `javascript:` and `vbscript:` checks.
  
No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
