### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL scheme check

### DIFF
--- a/test/fuzz.test.js
+++ b/test/fuzz.test.js
@@ -642,7 +642,8 @@ describe('Fuzz Testing (Property-based Testing)', () => {
               if (res) {
                 const decoded = fullyDecode(res);
                 if (decoded.startsWith('javascript:') ||
-                    decoded.startsWith('vbscript:')) {
+                    decoded.startsWith('vbscript:') ||
+                    decoded.startsWith('data:')) {
                   console.error(
                     'Bypass detected via Mixed Encoding URL:',
                     directUrl, '\nResult:', res
@@ -661,7 +662,8 @@ describe('Fuzz Testing (Property-based Testing)', () => {
               if (res && typeof res === 'string') {
                 const decoded = fullyDecode(res);
                 if (decoded.includes('javascript:') ||
-                  decoded.includes('vbscript:')) {
+                  decoded.includes('vbscript:') ||
+                  decoded.includes('data:')) {
                   console.error(
                     'Bypass detected via Mixed Encoding Data URL:',
                     dataUrl, '\nResult:', res


### PR DESCRIPTION
Potential fix for [https://github.com/asamuzaK/urlSanitizer/security/code-scanning/11](https://github.com/asamuzaK/urlSanitizer/security/code-scanning/11)

To fix this without changing intended functionality, extend the scheme checks in `test/fuzz.test.js` so they also match `data:` alongside `javascript:` and `vbscript:`.

Best single approach:
- In the direct URL result validation block (around lines 644–645), add `decoded.startsWith('data:')`.
- In the data URL validation block (around lines 663–664), add `decoded.includes('data:')`.

This keeps the existing test structure and behavior while closing the incomplete scheme coverage identified by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
